### PR TITLE
Reword isSingularity() brief to avoid Doxygen line break

### DIFF
--- a/modules/juce_graphics/geometry/juce_AffineTransform.h
+++ b/modules/juce_graphics/geometry/juce_AffineTransform.h
@@ -255,7 +255,7 @@ public:
     /** Returns true if this transform has no effect on points. */
     bool isIdentity() const noexcept;
 
-    /** Returns true if this transform maps to a singularity - i.e. if it has no inverse. */
+    /** Returns true if this transform maps to a singularity (i.e., has no inverse). */
     bool isSingularity() const noexcept;
 
     /** Returns true if the transform only translates, and doesn't scale or rotate the points. */


### PR DESCRIPTION
The period in "i.e." was previously interpreted as the end of a brief description.